### PR TITLE
Desacoplar el scheduler del fallback lento de Playwright

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,17 @@
 # Token HTTP API de tu bot de Telegram
 # ⚠️  CRÍTICO: Sin este token, el bot no funcionará
 TELEGRAM_BOT_TOKEN=tu_token_aqui_sin_comillas
+
+# --- Scheduler: intervalos de revisión ---
+# El scheduler usa dos jobs independientes para que una ruta que necesite
+# recapturar sesión con Playwright (10-30s) no retrase la comprobación del
+# resto de rutas. Ver "Configuración avanzada" en el README para más detalle.
+
+# Cada cuánto se comprueba la sesión de Renfe ya cacheada (sin abrir navegador)
+FAST_CHECK_INTERVAL_SECONDS=3
+
+# Cada cuánto se recaptura con Playwright la sesión de las rutas sin cache válido
+SESSION_REFRESH_INTERVAL_SECONDS=20
+
+# Máximo de recapturas de sesión con Playwright en paralelo (navegadores simultáneos)
+MAX_CONCURRENT_REFRESHES=2

--- a/README.md
+++ b/README.md
@@ -109,13 +109,28 @@ renfe-bot/
 
 ### Cambiar intervalo de revisión de alertas
 
-En `scheduler.py`, línea 38, cambia `seconds=5` por el intervalo que prefieras:
-```python
-# Para revisar cada 5 segundos en producción:
-scheduler.add_job(check_alerts, 'interval', seconds=5)
+`scheduler.py` corre dos jobs independientes para que una ruta que necesite
+recapturar sesión con Playwright (10-30s) no retrase la comprobación del
+resto de rutas:
 
-# Para cada 30 segundos (depuración):
-scheduler.add_job(check_alerts, 'interval', seconds=30)
+- `fast_check_alerts`: solo lee la sesión ya cacheada (sin abrir navegador).
+  Si una ruta no tiene cache válido, se salta ese ciclo para esa ruta.
+- `refresh_sessions`: recaptura con Playwright solo las rutas activas sin
+  cache válido, acotado por un semáforo para no abrir demasiados navegadores
+  a la vez. Si la recaptura ya trae plaza libre, notifica al instante.
+
+Ambos intervalos (y el límite de recapturas concurrentes) se configuran por
+variables de entorno en `.env` (ver `.env.example`):
+
+```bash
+# Cada cuánto se comprueba la sesión cacheada (recomendado 3s)
+FAST_CHECK_INTERVAL_SECONDS=3
+
+# Cada cuánto se recaptura con Playwright la sesión de las rutas sin cache (recomendado 20s)
+SESSION_REFRESH_INTERVAL_SECONDS=20
+
+# Máximo de recapturas con Playwright en paralelo (recomendado 2)
+MAX_CONCURRENT_REFRESHES=2
 ```
 
 ### Usar una base de datos centralizada

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,19 +1,22 @@
 import os
 import asyncio
 import logging
-from typing import Dict, List, Tuple, TypedDict
+from typing import Any, Dict, List, Tuple, TypedDict
 
 from dotenv import load_dotenv
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from telegram import Bot
 
-from scraper import get_trains
-from database import get_active_alerts, delete_alert, init_db
+from scraper import build_search_key, get_trains_cached_only, refresh_session
+from database import get_active_alerts, delete_alert, get_session_cache, init_db
 
 from datetime import datetime
 
 load_dotenv()
 TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+FAST_CHECK_INTERVAL_SECONDS = int(os.getenv("FAST_CHECK_INTERVAL_SECONDS", "3"))
+SESSION_REFRESH_INTERVAL_SECONDS = int(os.getenv("SESSION_REFRESH_INTERVAL_SECONDS", "20"))
+MAX_CONCURRENT_REFRESHES = int(os.getenv("MAX_CONCURRENT_REFRESHES", "2"))
 
 logging.basicConfig(
     format='%(asctime)s - SCHEDULER - %(levelname)s - %(message)s',
@@ -52,8 +55,8 @@ async def _notify_users_for_route(
     destination: str,
     date: str,
     users_waiting: List[WaitingUser],
+    trenes: List[Dict[str, Any]],
 ):
-    trenes = await get_trains(origin, destination, date)
     if not trenes:
         return
 
@@ -83,13 +86,12 @@ async def _notify_users_for_route(
             except Exception as e:
                 logger.error("Error enviando mensaje: %s", e)
 
-async def check_alerts():
-    logger.info("Iniciando revisión de alertas...")
-
+def _get_valid_grouped_alerts() -> GroupedAlerts:
+    """Descarta alertas de trenes ya pasados y agrupa el resto por ruta+fecha."""
     alerts = get_active_alerts()
     if not alerts:
-        return
-    
+        return {}
+
     now = datetime.now()
     valid_alerts = []
 
@@ -109,17 +111,78 @@ async def check_alerts():
             logger.error("Error al comprobar la caducidad de la alerta %s: %s", alert_id, e)
             valid_alerts.append(alert)
 
-    if not valid_alerts:
-        logger.info("Todas las alertas estaban caducadas. Fin de revisión.")
+    return _group_alerts(valid_alerts)
+
+
+async def fast_check_alerts():
+    """Job rapido: solo lee la sesion cacheada, nunca abre Playwright.
+
+    Si una ruta no tiene sesion cacheada valida, se salta ese ciclo para esa
+    ruta sin bloquear la comprobacion de las demas. `refresh_sessions` es
+    quien se encarga de recapturar la sesion con Playwright.
+    """
+    grouped_searches = _get_valid_grouped_alerts()
+    if not grouped_searches:
         return
-    
-    grouped_searches = _group_alerts(valid_alerts)
 
     async with Bot(token=TOKEN) as bot:
         for (origin, destination, date), users_waiting in grouped_searches.items():
-            await _notify_users_for_route(bot, origin, destination, date, users_waiting)
+            try:
+                trenes = await get_trains_cached_only(origin, destination, date)
+            except Exception as e:
+                logger.exception("Error en fast_check_alerts para %s -> %s: %s", origin, destination, e)
+                continue
 
-    logger.info("Revisión de alertas finalizada.")
+            if trenes is None:
+                continue
+
+            await _notify_users_for_route(bot, origin, destination, date, users_waiting, trenes)
+
+
+async def _refresh_route(
+    semaphore: asyncio.Semaphore,
+    bot: Bot,
+    origin: str,
+    destination: str,
+    date: str,
+    users_waiting: List[WaitingUser],
+):
+    async with semaphore:
+        try:
+            trenes = await refresh_session(origin, destination, date)
+        except Exception as e:
+            logger.exception("Error recapturando sesion para %s -> %s: %s", origin, destination, e)
+            return
+
+    await _notify_users_for_route(bot, origin, destination, date, users_waiting, trenes)
+
+
+async def refresh_sessions():
+    """Job lento: recaptura con Playwright solo las rutas sin cache valido.
+
+    Acotado por `MAX_CONCURRENT_REFRESHES` para no abrir demasiados
+    navegadores a la vez. Si la recaptura ya trae plaza libre, notifica al
+    instante en vez de esperar al siguiente `fast_check_alerts`.
+    """
+    grouped_searches = _get_valid_grouped_alerts()
+    if not grouped_searches:
+        return
+
+    routes_needing_refresh = [
+        (route, users_waiting)
+        for route, users_waiting in grouped_searches.items()
+        if get_session_cache(build_search_key(*route)) is None
+    ]
+
+    if not routes_needing_refresh:
+        return
+
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_REFRESHES)
+    async with Bot(token=TOKEN) as bot:
+        await asyncio.gather(*[
+            _refresh_route(semaphore, bot, origin, destination, date, users_waiting)
+            for (origin, destination, date), users_waiting in routes_needing_refresh
+        ])
 
 async def main():
     if not TOKEN:
@@ -130,8 +193,21 @@ async def main():
 
     init_db()
     scheduler = AsyncIOScheduler()
-    scheduler.add_job(check_alerts, 'interval', seconds=5)
-    logger.info("Job programado: revisar alertas cada 5 segundos")
+    scheduler.add_job(
+        fast_check_alerts, 'interval',
+        seconds=FAST_CHECK_INTERVAL_SECONDS,
+        max_instances=1, coalesce=True,
+    )
+    scheduler.add_job(
+        refresh_sessions, 'interval',
+        seconds=SESSION_REFRESH_INTERVAL_SECONDS,
+        max_instances=1, coalesce=True,
+    )
+    logger.info(
+        "Jobs programados: fast_check_alerts cada %ss (solo cache), "
+        "refresh_sessions cada %ss (Playwright, max %s concurrentes)",
+        FAST_CHECK_INTERVAL_SECONDS, SESSION_REFRESH_INTERVAL_SECONDS, MAX_CONCURRENT_REFRESHES,
+    )
 
     scheduler.start()
 

--- a/scraper.py
+++ b/scraper.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 ALLOWED_RESOURCE_TYPES = ["document", "script", "xhr", "fetch"]
 
 
-def _build_search_key(origin: str, destination: str, date_str: str) -> str:
+def build_search_key(origin: str, destination: str, date_str: str) -> str:
     return f"{origin}-{destination}-{date_str}"
 
 
@@ -314,7 +314,16 @@ async def _capture_session_with_playwright(
 
 
 async def get_trains(origin: str, destination: str, date_str: str) -> List[Dict[str, Any]]:
-    search_key = _build_search_key(origin, destination, date_str)
+    """Consulta trenes: intenta la sesion cacheada y si falla, cae a Playwright.
+
+    Pensada para el flujo de un solo usuario (alta de alerta desde `main.py`),
+    donde bloquear unos segundos en el fallback lento es aceptable. El
+    scheduler NO debe usar esta funcion para su barrido periodico: usa
+    `get_trains_cached_only` (rapido, sin Playwright) y `refresh_session`
+    (Playwright, acotado por semaforo) para no acoplar el intervalo de todas
+    las rutas a la mas lenta.
+    """
+    search_key = build_search_key(origin, destination, date_str)
 
     logger.info("Intentando usar sesion cacheada para %s", search_key)
     try:
@@ -326,4 +335,38 @@ async def get_trains(origin: str, destination: str, date_str: str) -> List[Dict[
         logger.exception("Error en llamada API directa: %s", e)
         delete_session_cache(search_key)
 
+    return await _capture_session_with_playwright(origin, destination, date_str, search_key)
+
+
+async def get_trains_cached_only(
+    origin: str, destination: str, date_str: str
+) -> Optional[List[Dict[str, Any]]]:
+    """Consulta trenes usando SOLO la sesion cacheada, sin abrir Playwright.
+
+    Pensada para el job rapido del scheduler: si no hay cache o la sesion ha
+    caducado, devuelve None de inmediato (borrando el cache caducado para que
+    `refresh_sessions` la recapture) en vez de bloquear ese ciclo con el
+    fallback lento de Playwright.
+    """
+    search_key = build_search_key(origin, destination, date_str)
+
+    try:
+        cached_result = await _fetch_with_cached_session(search_key, date_str)
+        if cached_result is not None:
+            return cached_result
+    except Exception as e:
+        logger.exception("Error en llamada API directa (cache-only) para %s: %s", search_key, e)
+
+    delete_session_cache(search_key)
+    return None
+
+
+async def refresh_session(origin: str, destination: str, date_str: str) -> List[Dict[str, Any]]:
+    """Recaptura la sesion de Renfe via Playwright y cachea el resultado.
+
+    Pensada para el job lento del scheduler (`refresh_sessions`), que la
+    invoca solo para las rutas sin cache valido y acotado por un semaforo
+    para no abrir demasiados navegadores a la vez.
+    """
+    search_key = build_search_key(origin, destination, date_str)
     return await _capture_session_with_playwright(origin, destination, date_str, search_key)


### PR DESCRIPTION
Resuelve mauroz9/trainpicker#1.

## Problema

`scheduler.py` revisaba todas las alertas en un único job `check_alerts`
cada 5s. Cuando una ruta necesitaba recapturar sesión con Playwright
(10-30s, ver `scraper.get_trains` → `_capture_session_with_playwright`),
ese ciclo entero se bloqueaba esperando al navegador. Como APScheduler no
solapa ejecuciones del mismo job (`max_instances=1` por defecto), el
siguiente ciclo se saltaba mientras el anterior seguía corriendo — así que
una sola ruta lenta retrasaba la notificación de **todas** las rutas, no
solo la suya.

## Análisis

- `scraper.get_trains` siempre intenta la sesión cacheada primero
  (`_fetch_with_cached_session`, HTTP directo vía `httpx`) y si falla o no
  hay cache, cae a `_capture_session_with_playwright` (abre un navegador
  Chromium headless y repite todo el flujo de búsqueda en renfe.com).
- Ese fallback es correcto para el flujo de un solo usuario en `main.py`
  (dar de alta una alerta), donde bloquear unos segundos es aceptable.
- Pero el scheduler reutilizaba la misma función para su barrido periódico
  de *todas* las rutas activas, acoplando el intervalo global al caso más
  lento.

## Solución

**`scraper.py`** — se añaden dos funciones nuevas, sin tocar `get_trains`
(que sigue usando `main.py` sin cambios):
- `get_trains_cached_only(origin, destination, date_str)`: usa solo la
  sesión cacheada. Si no hay cache o ha caducado, borra el cache caducado y
  devuelve `None` de inmediato — nunca abre Playwright.
- `refresh_session(origin, destination, date_str)`: recaptura sesión con
  Playwright directamente (equivalente al fallback anterior) y cachea el
  resultado.
- `_build_search_key` pasa a ser pública (`build_search_key`) para poder
  comprobar existencia de cache desde `scheduler.py`.

**`scheduler.py`** — `check_alerts` se sustituye por dos jobs independientes:
- `fast_check_alerts` (cada `FAST_CHECK_INTERVAL_SECONDS`, default 3s): solo
  lee cache. Si una ruta no tiene cache válido, se salta esa ruta ese ciclo
  sin bloquear las demás.
- `refresh_sessions` (cada `SESSION_REFRESH_INTERVAL_SECONDS`, default 20s):
  recaptura con Playwright solo las rutas activas cuyo cache ya no existe
  (`get_session_cache(...) is None`), acotado por
  `asyncio.Semaphore(MAX_CONCURRENT_REFRESHES)` (default 2) para no abrir
  demasiados navegadores a la vez. Si la recaptura ya trae plaza libre,
  notifica al instante en vez de esperar al siguiente `fast_check_alerts`.
- Ambos jobs con `max_instances=1, coalesce=True`.
- La lógica compartida de expirar alertas de trenes pasados y agruparlas por
  ruta+fecha se extrae a `_get_valid_grouped_alerts()`, usada por ambos jobs.
- `_notify_users_for_route` ahora recibe la lista de trenes ya obtenida en
  vez de volver a llamar a `get_trains` internamente, para poder compartirla
  entre los dos jobs.

Los tres intervalos son configurables por variable de entorno
(`.env.example` actualizado; `docker-compose.yml` ya pasa `.env` entero así
que no requiere cambios). README actualizado en "Cambiar intervalo de
revisión de alertas".

## Test plan

No había suite de tests en el repo. Verificado manualmente:
- [x] `python -m py_compile` sobre los 4 archivos tocados + `main.py`.
- [x] Import real de `scheduler.py` y `scraper.py` en un venv con las
  dependencias instaladas (confirma que no hay referencias rotas tras el
  refactor, p.ej. el rename de `_build_search_key`).
- [x] Script de humo con `unittest.mock` sobre una copia real de
  `database.py` (SQLite temporal) y `scheduler.Bot`/`get_trains_cached_only`/
  `refresh_session` mockeados, cubriendo:
  - 3 alertas activas en 2 rutas (`MADRID→BARCELONA` con 2 usuarios,
    `SEVILLA→MADRID` con 1).
  - `fast_check_alerts` con cache disponible solo en una ruta: notifica solo
    al usuario de esa ruta y borra su alerta; la otra ruta se salta sin
    error y sus alertas quedan intactas.
  - `refresh_sessions` sin cache en ninguna ruta activa restante: recaptura
    ambas rutas vía Playwright (mock) en paralelo, y notifica al instante al
    usuario cuya recaptura trae plaza libre.
  - Estado final de la base de datos consistente con las notificaciones
    enviadas (solo queda activa la alerta que no tenía plaza).
- [x] No se ha probado contra Renfe real (`refresh_session` end-to-end con
  Playwright de verdad) — recomendable verificarlo en staging/producción
  antes o justo después de desplegar, dado que ahora puede haber hasta
  `MAX_CONCURRENT_REFRESHES` navegadores Playwright abiertos a la vez.

🤖 Generated with [Claude Code](https://claude.com/claude-code)