### PR TITLE
fix: WAL + busy_timeout en SQLite para evitar 'database is locked'

### DIFF
--- a/database.py
+++ b/database.py
@@ -13,8 +13,10 @@ UserAlert = Tuple[int, str, str, str, str, str, int]
 
 @contextmanager
 def _get_connection() -> Generator[sqlite3.Connection, None, None]:
-    conn = sqlite3.connect(DB_NAME)
+    conn = sqlite3.connect(DB_NAME, timeout=10)
     try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=10000")
         yield conn
     finally:
         conn.close()


### PR DESCRIPTION
## Resumen

- `database.py` abría conexiones SQLite con `sqlite3.connect(DB_NAME)`, sin `timeout` ni `journal_mode` configurado.
- Bot (`main.py`) y scheduler (`scheduler.py`) escriben sobre el mismo `.db` en un volumen Docker compartido. Con el chequeo rápido de alertas pasando cada pocos segundos (tras #10, que desacopló el scheduler del fallback lento de Playwright), el riesgo real de colisión de escritura aumentó.
- Reproduje el fallo localmente: dos hilos escribiendo a la vez sobre el mismo `.db`, uno con una transacción `BEGIN IMMEDIATE` en curso — sin el fix, el segundo escritor falla al instante con `sqlite3.OperationalError: database is locked`.

## Cambio

En `_get_connection()` (`database.py:15`):
- `sqlite3.connect(DB_NAME, timeout=10)` en vez de sin timeout.
- `PRAGMA busy_timeout=10000` y `PRAGMA journal_mode=WAL` en cada conexión antes de usarla.

Con esto, en vez de fallar al instante, SQLite espera hasta 10s a que el lock se libere; y WAL permite lecturas concurrentes mientras hay una escritura en curso (el caso típico: bot leyendo alertas del usuario mientras el scheduler escribe `session_cache`).

## Verificación

Prueba manual (no cubierta por CI, ver #9 sobre falta de tests):

```
--- WITHOUT fix (default connect, no timeout) ---
['FAIL: database is locked']
--- WITH fix (timeout=10, WAL, busy_timeout) ---
['OK']
```

Además, `init_db()` + `add_alert()` + `get_active_alerts()` funcionan igual que antes con el nuevo modo de journaling (verificado en una DB de scratch).

Nota: `journal_mode=WAL` crea ficheros auxiliares `renfe_alerts.db-wal` y `renfe_alerts.db-shm` junto al `.db` — es el comportamiento normal de WAL en SQLite, no requiere cambios en el volumen Docker.

## Test plan

- [x] Reproducido el error `database is locked` sin el fix.
- [x] Confirmado que con el fix la escritura concurrente ya no falla.
- [x] `init_db()` y operaciones CRUD básicas siguen funcionando.

Resuelve mauroz9/trainpicker#2