### PR TITLE
fix: añadir .dockerignore para evitar fuga de secretos en la imagen Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.env
+.git
+data/
+__pycache__/
+*.pyc
+error_renfe.png


### PR DESCRIPTION
## Resumen

- No existía `.dockerignore` en la raíz del proyecto.
- El `Dockerfile` hace `COPY . .` (línea final), que copia todo el contexto de build al directorio `/app` de la imagen.
- Si al hacer `docker-compose up --build` existen en el directorio local `.env` (token de Telegram), `.git/` o `data/*.db` (alertas y user_ids reales), quedan embebidos en las capas de la imagen — recuperables incluso si un paso posterior los borrase, vía `docker history`/capas intermedias.

## Cambio

Nuevo `.dockerignore` en la raíz, excluyendo:
- `.env`
- `.git`
- `data/`
- `__pycache__/`
- `*.pyc`
- `error_renfe.png`

## Verificación

Monté una réplica mínima fuera del repo (Dockerfile trivial `FROM alpine` + `COPY . .` + `find /app`) con archivos ficticios simulando `.env`, `.git/config` y `data/renfe_alerts.db`, para no tener que reconstruir la imagen real completa (que instala Chromium vía Playwright y tarda varios minutos).

**Sin `.dockerignore`:**
```
/app/error_renfe.png
/app/.env
/app/data/renfe_alerts.db
/app/.git/config
```

**Con el `.dockerignore` de este PR:**
```
/app/.dockerignore
/app/Dockerfile
```

Los tres archivos sensibles desaparecen del contexto de build.

## Test plan

- [x] Reproducido que sin `.dockerignore` los secretos/datos acaban en la imagen.
- [x] Confirmado que con el `.dockerignore` añadido no aparecen en el contenido copiado.
- [x] (Opcional, no ejecutado aquí) build completo con el Dockerfile real del repo, para confirmar que no rompe el build — el cambio es aditivo y no toca el Dockerfile, así que el riesgo es mínimo.

Resuelve mauroz9/trainpicker#3