### PR TITLE
Corregir fail-open silencioso y heurística incorrecta en parseo DWR de Renfe

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -32,12 +32,32 @@ def parsear_dwr_renfe(texto_dwr: str, date_str: str) -> List[Dict[str, Any]]:
     """
     Parsea la respuesta DWR de Renfe.
 
-    Disponibilidad: se usa `completo` (flag booleano que Renfe ya calcula en
-    servidor con toda la informacion de plazas/tarifas) como señal principal,
-    combinada en OR con la triple regla heuristica original (tarifas nulas,
-    solo plazas H, o bloqueo tipo 3) para no perder cobertura frente a casos
-    que `completo` no contemplase. Ver PR de la tarea #12 para el analisis
-    con datos reales de Renfe que valida este comportamiento.
+    Disponibilidad: replica la logica real que usa el propio frontend de
+    Renfe (`listaTrenes.js`, funcion que decide entre las plantillas
+    `trenTemplateCompleto` / `trenTemplateBloqueado` / `trenTemplateNoCircula`
+    / `trenTemplateNoVenta`) para decidir si un tren es comprable, en vez de
+    una heuristica propia sin verificar. Un tren se considera NO disponible
+    si se cumple cualquiera de:
+      - `completo == true`.
+      - `razonNoDisponible` esta presente, no vacio y distinto de `"8"`
+        (Renfe usa el codigo "8" solo para incidencias informativas -p.ej.
+        limitaciones de velocidad de Adif- que no bloquean la venta; el resto
+        de codigos observados -"3" completo, "4" trayecto bloqueado, "5"/"6"/
+        "7" no circula- si la bloquean, igual que cualquier codigo nuevo no
+        catalogado, replicando el `else` final de esa misma funcion).
+      - `tarifasDisponibles == null` (sin tarifas no hay nada que comprar).
+    `soloPlazaH` NO se usa como señal de disponibilidad: se comprobo en
+    `listaTrenes.js` que solo cambia que plantilla se pinta (si el tren
+    tiene o no el icono de plaza H), nunca marca el tren como no disponible.
+    Ver PR de la tarea #5 para el analisis con datos reales y el volcado del
+    JS de Renfe que respalda esta logica.
+
+    Fail-closed ante roturas de formato: si ninguna de las tres señales
+    (`completo`, `tarifasDisponibles`, `razonNoDisponible`) matchea en un
+    bloque, se asume que Renfe cambio el formato del DWR. En vez de marcar el
+    tren como disponible por defecto (fail-open silencioso, tarea #5), se
+    marca como NO disponible y se loguea un warning explicito para detectar
+    la rotura cuanto antes.
 
     Ademas de `disponible` (contrato estable que consumen `main.py` y
     `scheduler.py`), se exponen campos adicionales del bloque -tren, duracion,
@@ -65,7 +85,6 @@ def parsear_dwr_renfe(texto_dwr: str, date_str: str) -> List[Dict[str, Any]]:
 
             completo_m = re.search(r'completo:\s*(true|false)', bloque)
             tarifas_m = re.search(r'tarifasDisponibles:\s*(null|\[)', bloque)
-            solo_plazah_m = re.search(r'soloPlazaH:\s*(true|false)', bloque)
             razon_m = re.search(r'razonNoDisponible:\s*(null|"[^"]*")', bloque)
 
             tren_m = re.search(r'cdgoTren:\s*"([^"]*)"', bloque)
@@ -82,20 +101,25 @@ def parsear_dwr_renfe(texto_dwr: str, date_str: str) -> List[Dict[str, Any]]:
                 origen_real = _decode_escaped_text(origen_m.group(1)) if origen_m else ""
                 destino_real = _decode_escaped_text(destino_m.group(1)) if destino_m else ""
 
-                is_full = False
-
-                if completo_m and completo_m.group(1) == 'true':
+                if not (completo_m or tarifas_m or razon_m):
+                    logger.warning(
+                        "parsear_dwr_renfe: no se encontro ninguna señal de disponibilidad "
+                        "(completo/tarifasDisponibles/razonNoDisponible) para el tren %s "
+                        "(salida %s, %s). Renfe pudo cambiar el formato del DWR; se marca "
+                        "como no disponible por seguridad.",
+                        tren_m.group(1) if tren_m else "?", salida, target_date,
+                    )
                     is_full = True
+                else:
+                    is_full = False
 
-                if tarifas_m and tarifas_m.group(1) == 'null':
-                    is_full = True
+                    if completo_m and completo_m.group(1) == 'true':
+                        is_full = True
 
-                if solo_plazah_m and solo_plazah_m.group(1) == 'true':
-                    is_full = True
+                    if tarifas_m and tarifas_m.group(1) == 'null':
+                        is_full = True
 
-                if razon_m:
-                    razon = razon_m.group(1)
-                    if razon == '"3"':
+                    if razon_m and razon_m.group(1) not in ('null', '"8"'):
                         is_full = True
 
                 tren_data = {

--- a/scraper.py
+++ b/scraper.py
@@ -32,12 +32,12 @@ def parsear_dwr_renfe(texto_dwr: str, date_str: str) -> List[Dict[str, Any]]:
     """
     Parsea la respuesta DWR de Renfe.
 
-    Disponibilidad: replica la logica real que usa el propio frontend de
+    Disponibilidad: parte de la logica real que usa el propio frontend de
     Renfe (`listaTrenes.js`, funcion que decide entre las plantillas
     `trenTemplateCompleto` / `trenTemplateBloqueado` / `trenTemplateNoCircula`
-    / `trenTemplateNoVenta`) para decidir si un tren es comprable, en vez de
-    una heuristica propia sin verificar. Un tren se considera NO disponible
-    si se cumple cualquiera de:
+    / `trenTemplateNoVenta`) para decidir si un tren es comprable, mas una
+    restriccion adicional de negocio propia de TrainPicker. Un tren se
+    considera NO disponible si se cumple cualquiera de:
       - `completo == true`.
       - `razonNoDisponible` esta presente, no vacio y distinto de `"8"`
         (Renfe usa el codigo "8" solo para incidencias informativas -p.ej.
@@ -46,18 +46,22 @@ def parsear_dwr_renfe(texto_dwr: str, date_str: str) -> List[Dict[str, Any]]:
         "7" no circula- si la bloquean, igual que cualquier codigo nuevo no
         catalogado, replicando el `else` final de esa misma funcion).
       - `tarifasDisponibles == null` (sin tarifas no hay nada que comprar).
-    `soloPlazaH` NO se usa como señal de disponibilidad: se comprobo en
-    `listaTrenes.js` que solo cambia que plantilla se pinta (si el tren
-    tiene o no el icono de plaza H), nunca marca el tren como no disponible.
+      - `soloPlazaH == true`: en el frontend de Renfe esto NO bloquea el
+        flujo de compra (solo cambia que plantilla/icono se pinta), pero
+        significa que las unicas plazas que quedan son plazas H, reservadas
+        para personas con movilidad reducida. Un usuario sin esa necesidad
+        no puede comprarlas en la practica, asi que para el caso de uso de
+        TrainPicker (avisar cuando se libera una plaza normal) se trata como
+        tren completo.
     Ver PR de la tarea #5 para el analisis con datos reales y el volcado del
     JS de Renfe que respalda esta logica.
 
-    Fail-closed ante roturas de formato: si ninguna de las tres señales
-    (`completo`, `tarifasDisponibles`, `razonNoDisponible`) matchea en un
-    bloque, se asume que Renfe cambio el formato del DWR. En vez de marcar el
-    tren como disponible por defecto (fail-open silencioso, tarea #5), se
-    marca como NO disponible y se loguea un warning explicito para detectar
-    la rotura cuanto antes.
+    Fail-closed ante roturas de formato: si ninguna de las cuatro señales
+    (`completo`, `tarifasDisponibles`, `razonNoDisponible`, `soloPlazaH`)
+    matchea en un bloque, se asume que Renfe cambio el formato del DWR. En
+    vez de marcar el tren como disponible por defecto (fail-open silencioso,
+    tarea #5), se marca como NO disponible y se loguea un warning explicito
+    para detectar la rotura cuanto antes.
 
     Ademas de `disponible` (contrato estable que consumen `main.py` y
     `scheduler.py`), se exponen campos adicionales del bloque -tren, duracion,
@@ -86,6 +90,7 @@ def parsear_dwr_renfe(texto_dwr: str, date_str: str) -> List[Dict[str, Any]]:
             completo_m = re.search(r'completo:\s*(true|false)', bloque)
             tarifas_m = re.search(r'tarifasDisponibles:\s*(null|\[)', bloque)
             razon_m = re.search(r'razonNoDisponible:\s*(null|"[^"]*")', bloque)
+            solo_plazah_m = re.search(r'soloPlazaH:\s*(true|false)', bloque)
 
             tren_m = re.search(r'cdgoTren:\s*"([^"]*)"', bloque)
             duracion_m = re.search(r'duracionViaje:\s*"([^"]*)"', bloque)
@@ -101,12 +106,12 @@ def parsear_dwr_renfe(texto_dwr: str, date_str: str) -> List[Dict[str, Any]]:
                 origen_real = _decode_escaped_text(origen_m.group(1)) if origen_m else ""
                 destino_real = _decode_escaped_text(destino_m.group(1)) if destino_m else ""
 
-                if not (completo_m or tarifas_m or razon_m):
+                if not (completo_m or tarifas_m or razon_m or solo_plazah_m):
                     logger.warning(
                         "parsear_dwr_renfe: no se encontro ninguna señal de disponibilidad "
-                        "(completo/tarifasDisponibles/razonNoDisponible) para el tren %s "
-                        "(salida %s, %s). Renfe pudo cambiar el formato del DWR; se marca "
-                        "como no disponible por seguridad.",
+                        "(completo/tarifasDisponibles/razonNoDisponible/soloPlazaH) para el "
+                        "tren %s (salida %s, %s). Renfe pudo cambiar el formato del DWR; se "
+                        "marca como no disponible por seguridad.",
                         tren_m.group(1) if tren_m else "?", salida, target_date,
                     )
                     is_full = True
@@ -120,6 +125,9 @@ def parsear_dwr_renfe(texto_dwr: str, date_str: str) -> List[Dict[str, Any]]:
                         is_full = True
 
                     if razon_m and razon_m.group(1) not in ('null', '"8"'):
+                        is_full = True
+
+                    if solo_plazah_m and solo_plazah_m.group(1) == 'true':
                         is_full = True
 
                 tren_data = {


### PR DESCRIPTION
Resuelve #5.

## Metodología

Siguiendo el punto 1 del "Cómo resolverlo" de la issue, no me limité a leer `scraper.py`: busqué en vivo el trayecto MD Puerto de Santa María → San Bernardo sugerido en la issue, e instrumenté `window.fetch`/`XMLHttpRequest` en el navegador para capturar la respuesta cruda de `trainEnlacesManager.getTrainsList.dwr` en múltiples fechas (barrí 3 semanas hacia adelante buscando trenes `completo:true`, sin encontrar ninguno en ese rango — la ruta no está actualmente saturada).

Como el objetivo real es "conocer todos los estados para no obtener falsos positivos/negativos", en vez de quedarme sin evidencia de `completo:true`, descargué y volqué el propio `listaTrenes.js` que sirve `venta.renfe.com` — el JS que Renfe usa en su frontend real para decidir si un tren se pinta como comprable o no. Esa es la fuente de verdad más fiable posible: es literalmente la lógica de negocio de Renfe, no una heurística reconstruida por fuera.

De ese JS extraje la función de decisión completa:

```js
if (tren.razonNoDisponible == "3" || tren.completo) {
    // -> trenTemplateCompleto (agotado)
} else if (tren.razonNoDisponible == "4") {
    // -> trenTemplateBloqueado (trayecto bloqueado)
} else if (razon == "5" || razon == "6" || razon == "7") {
    // -> trenTemplateNoCircula (no circula ese día)
} else if ((razon != "" && razon != "8") || tarifasDisponibles == null) {
    // -> trenTemplateNoVenta (código nuevo/no catalogado, o sin tarifas)
} else {
    // comprable (razon == "" / null / "8", con tarifas)
}
```

(`razonNoDisponible == "8"` es tratado aparte, solo como incidencia informativa —p.ej. el aviso de limitaciones de velocidad de Adif que se ve en el propio banner de la web—, nunca bloquea la venta.)

**Corrección tras la primera versión de este PR:** inicialmente eliminé `soloPlazaH` de la lógica porque, leyendo el JS, confirmé que Renfe no lo usa en absoluto para decidir si el tren se pinta como completo (solo cambia una plantilla/icono visual). Pero el usuario me hizo notar algo que el JS de Renfe no refleja: cuando `soloPlazaH` es `true`, las únicas plazas que quedan son plazas H, reservadas para personas con movilidad reducida — un usuario normal no puede comprarlas en la práctica, aunque el flujo de compra de Renfe no lo bloquee explícitamente a nivel de UI. Para el caso de uso de TrainPicker (avisar cuando se libera una plaza *normal*), eso equivale a tren completo, así que se mantuvo como señal de "completo" (igual que en la heurística original), documentando explícitamente que es una restricción de negocio propia de TrainPicker y no algo que haga el propio Renfe.

## Qué cambia en `parsear_dwr_renfe` (`scraper.py`)

1. **Fail-open silencioso (el bug original de la issue):** si ninguna de las cuatro señales (`completo`, `tarifasDisponibles`, `razonNoDisponible`, `soloPlazaH`) matchea en un bloque, ahora se loguea un `warning` explícito y el tren se marca **no disponible** (fail-closed), en vez de disponible por defecto sin evidencia.
2. **Cobertura completa de `razonNoDisponible`.** Antes solo se trataba el código `"3"` como bloqueante. Ahora, replicando el `else` final de la función real de Renfe, se trata como no disponible **cualquier** código presente y no vacío salvo `"8"` (informativo) — cubre los códigos `4`, `5`, `6`, `7` observados, y cualquier código futuro no catalogado (fail-closed también ahí).
3. `soloPlazaH` se mantiene como señal de "completo" (ver corrección arriba), documentando explícitamente por qué diverge de lo que hace el frontend real de Renfe.

## Validación

- `python3 -m py_compile scraper.py scheduler.py main.py database.py` sin errores.
- Ejecuté `parsear_dwr_renfe` con la respuesta DWR real capturada (34 bloques, ruta MD Puerto de Santa María → San Bernardo, 26 trenes únicos tras dedupe: 15 marcados no disponibles por `soloPlazaH`) y con casos sintéticos cubriendo cada rama nueva:

  | Caso | `disponible` |
  |---|---|
  | `completo:true` | `False` |
  | `razonNoDisponible:"3"` | `False` |
  | `razonNoDisponible:"8"` (informativo) | `True` |
  | `tarifasDisponibles:null` sin razón | `False` |
  | `soloPlazaH:true` | `False` |
  | bloque sin ninguna de las 4 señales (formato roto simulado) | `False` + `warning` en logs |
  | caso normal disponible | `True` |

  Todos se comportan como se espera.

## Archivos tocados
- `scraper.py` — `parsear_dwr_renfe`: lógica de disponibilidad reescrita y documentada, fail-closed ante roturas de formato.

🤖 Generado con [Claude Code](https://claude.com/claude-code)