### PR TITLE
feat: alerta al admin ante fallos consecutivos de refresh_session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,17 @@ SESSION_REFRESH_INTERVAL_SECONDS=20
 
 # Máximo de recapturas de sesión con Playwright en paralelo (navegadores simultáneos)
 MAX_CONCURRENT_REFRESHES=2
+
+# --- Auto-vigilancia del scraper (opcional) ---
+# Si Renfe cambia el HTML/selectores de su web, la recaptura de sesión con
+# Playwright empieza a fallar en silencio. Configurando estas dos variables,
+# el scheduler te avisa por Telegram cuando eso pase. Ver "Configuración
+# avanzada" en el README para más detalle.
+
+# Chat ID de Telegram al que se envía la alerta. Vacío = función desactivada.
+# Para obtener tu chat ID: escríbele a @userinfobot en Telegram, o mira el
+# id numérico que el bot registra en los logs al recibir un mensaje tuyo.
+ADMIN_CHAT_ID=
+
+# Nº de capturas de sesión fallidas seguidas a partir del cual se avisa
+ADMIN_FAILURE_THRESHOLD=5

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -39,3 +39,17 @@ SESSION_REFRESH_INTERVAL_SECONDS=20
 
 # Máximo de recapturas de sesión con Playwright en paralelo (navegadores simultáneos)
 MAX_CONCURRENT_REFRESHES=2
+
+# --- Auto-vigilancia del scraper (opcional) ---
+# Si Renfe cambia el HTML/selectores de su web, la recaptura de sesión con
+# Playwright empieza a fallar en silencio. Configurando estas dos variables,
+# el scheduler te avisa por Telegram cuando eso pase. Ver "Configuración
+# avanzada" en el README para más detalle.
+
+# Chat ID de Telegram al que se envía la alerta. Vacío = función desactivada.
+# Para obtener tu chat ID: escríbele a @userinfobot en Telegram, o mira el
+# id numérico que el bot registra en los logs al recibir un mensaje tuyo.
+ADMIN_CHAT_ID=
+
+# Nº de capturas de sesión fallidas seguidas a partir del cual se avisa
+ADMIN_FAILURE_THRESHOLD=5

--- a/README.md
+++ b/README.md
@@ -138,6 +138,30 @@ SESSION_REFRESH_INTERVAL_SECONDS=20
 MAX_CONCURRENT_REFRESHES=2
 ```
 
+### Alerta al admin si el scraper deja de funcionar
+
+Si Renfe cambia el HTML/selectores de su formulario de búsqueda, la
+recaptura de sesión con Playwright (`refresh_session`) empieza a fallar en
+todos los ciclos. Sin esta comprobación eso es indistinguible de "no hay
+trenes disponibles", así que el bot deja de detectar plazas libres para
+todas las alertas activas sin que nadie se entere.
+
+Configurando `ADMIN_CHAT_ID` en `.env`, el scheduler te manda un mensaje de
+Telegram en cuanto se acumulan varios fallos de captura seguidos (una sola
+vez por incidencia, no en cada ciclo):
+
+```bash
+# Chat ID de Telegram al que se envía la alerta. Vacío = función desactivada.
+ADMIN_CHAT_ID=
+
+# Nº de capturas de sesión fallidas seguidas a partir del cual se avisa (por defecto 5)
+ADMIN_FAILURE_THRESHOLD=5
+```
+
+Para obtener tu chat ID de Telegram: escríbele a
+[@userinfobot](https://t.me/userinfobot), o mira el id numérico que el bot
+registra en los logs al recibir un mensaje tuyo.
+
 ### Usar una base de datos centralizada
 
 Por defecto, las alertas se guardan en `data/renfe_alerts.db` dentro del contenedor. Para persistencia real:

--- a/scheduler.py
+++ b/scheduler.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from telegram import Bot
 
-from scraper import build_search_key, close_browser, get_trains_cached_only, refresh_session
+from scraper import build_search_key, close_browser, get_consecutive_capture_failures, get_trains_cached_only, refresh_session
 from database import get_active_alerts, delete_alert, get_session_cache, init_db
 
 from datetime import datetime
@@ -17,12 +17,24 @@ TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 FAST_CHECK_INTERVAL_SECONDS = int(os.getenv("FAST_CHECK_INTERVAL_SECONDS", "3"))
 SESSION_REFRESH_INTERVAL_SECONDS = int(os.getenv("SESSION_REFRESH_INTERVAL_SECONDS", "20"))
 MAX_CONCURRENT_REFRESHES = int(os.getenv("MAX_CONCURRENT_REFRESHES", "2"))
+# Alerta al admin si la captura de sesion de Renfe (Playwright) falla varias
+# veces seguidas: puede indicar que Renfe cambio su web (issue #22). Opcional:
+# si ADMIN_CHAT_ID no esta configurado, esta comprobacion se desactiva.
+ADMIN_CHAT_ID = os.getenv("ADMIN_CHAT_ID")
+ADMIN_FAILURE_THRESHOLD = int(os.getenv("ADMIN_FAILURE_THRESHOLD", "5"))
 
 logging.basicConfig(
     format='%(asctime)s - SCHEDULER - %(levelname)s - %(message)s',
     level=logging.INFO
 )
 logger = logging.getLogger(__name__)
+
+if not ADMIN_CHAT_ID:
+    logger.info("ADMIN_CHAT_ID no configurado: alertas de fallo consecutivo del scraper desactivadas")
+
+# Evita reenviar la alerta en cada ciclo mientras el fallo persiste: solo se
+# notifica en la transicion a estado "fallando" y se resetea al recuperarse.
+_admin_already_alerted = False
 
 
 class WaitingUser(TypedDict):
@@ -157,6 +169,32 @@ async def _refresh_route(
     await _notify_users_for_route(bot, origin, destination, date, users_waiting, trenes)
 
 
+async def _check_admin_alert(bot: Bot):
+    """Avisa al admin (una sola vez por racha) si el scraper lleva varios
+    fallos consecutivos capturando la sesion de Renfe. Ver issue #22."""
+    global _admin_already_alerted
+
+    if not ADMIN_CHAT_ID:
+        return
+
+    failures = get_consecutive_capture_failures()
+
+    if failures == 0:
+        _admin_already_alerted = False
+        return
+
+    if failures >= ADMIN_FAILURE_THRESHOLD and not _admin_already_alerted:
+        mensaje = (
+            f"⚠️ TrainPicker: {failures} capturas de Renfe consecutivas han "
+            f"fallado — Renfe pudo cambiar su web. Revisa los logs."
+        )
+        try:
+            await bot.send_message(chat_id=ADMIN_CHAT_ID, text=mensaje)
+            _admin_already_alerted = True
+        except Exception as e:
+            logger.error("Error enviando alerta de admin: %s", e)
+
+
 async def refresh_sessions():
     """Job lento: recaptura con Playwright solo las rutas sin cache valido.
 
@@ -183,6 +221,7 @@ async def refresh_sessions():
             _refresh_route(semaphore, bot, origin, destination, date, users_waiting)
             for (origin, destination, date), users_waiting in routes_needing_refresh
         ])
+        await _check_admin_alert(bot)
 
 async def main():
     if not TOKEN:

--- a/scraper.py
+++ b/scraper.py
@@ -13,6 +13,15 @@ logger = logging.getLogger(__name__)
 ALLOWED_RESOURCE_TYPES = ["document", "script", "xhr", "fetch"]
 AUTOCOMPLETE_TYPE_DELAY_MS = 60
 
+# Contador de fallos consecutivos de _capture_session_with_playwright. Permite a
+# scheduler.py detectar roturas del scraper (p.ej. Renfe cambia su web) que de
+# otro modo son indistinguibles de "no hay trenes disponibles" (issue #22).
+_consecutive_capture_failures: int = 0
+
+
+def get_consecutive_capture_failures() -> int:
+    return _consecutive_capture_failures
+
 
 def _sanitize_headers(headers: Dict[str, str]) -> Dict[str, str]:
     return {
@@ -247,6 +256,8 @@ async def _capture_session_with_playwright(
     date_str: str,
     search_key: str,
 ) -> List[Dict[str, Any]]:
+    global _consecutive_capture_failures
+
     logger.info("Iniciando Playwright para capturar sesion de Renfe")
 
     browser = await _get_browser()
@@ -414,9 +425,12 @@ async def _capture_session_with_playwright(
         )
         logger.info("Sesion y tokens de Renfe cacheados con exito")
 
+        _consecutive_capture_failures = 0
+
         return parsear_dwr_renfe(texto_dwr, date_str)
 
     except Exception as e:
+        _consecutive_capture_failures += 1
         logger.exception("Error durante captura de sesion DWR: %s", e)
         await page.screenshot(path="error_renfe.png", full_page=True)
         return []


### PR DESCRIPTION
## Summary
- Detecta rachas de fallos consecutivos capturando la sesión de Renfe (`_capture_session_with_playwright`), que hoy quedan totalmente silenciosas y se confunden con "no hay trenes disponibles".
- Si el contador cruza `ADMIN_FAILURE_THRESHOLD` (env, default 5), `scheduler.py` manda un Telegram a `ADMIN_CHAT_ID` (env, opcional) — una sola vez por racha, no en cada ciclo.
- Documentadas ambas variables en `.env.example`, `.env.prod.example` y el README.

Closes #22.

## Test plan
- [x] `python -m py_compile scraper.py scheduler.py`
- [x] Desplegar y confirmar en logs que, con `ADMIN_CHAT_ID` sin configurar, la comprobación queda desactivada sin errores.
- [x] Configurar `ADMIN_CHAT_ID` y forzar una racha de fallos (o bajar `ADMIN_FAILURE_THRESHOLD` a 1 temporalmente) para confirmar que llega el Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)